### PR TITLE
🔀 :: (#23) UUID 생성 방식 수정

### DIFF
--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/Application.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/Application.kt
@@ -8,7 +8,7 @@ import java.util.*
 @Aggregate
 class Application(
 
-    val id: UUID,
+    val id: UUID = UUID(0, 0),
 
     val studentId: UUID,
 
@@ -20,7 +20,7 @@ class Application(
 
     val reason: String,
 
-    val isStatus: Boolean,
+    val isStatus: Boolean = false,
 
-    val isPermission: Boolean,
+    val isPermission: Boolean = false,
 )

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/Status.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/Status.kt
@@ -2,12 +2,12 @@ package com.pickdsm.pickserverspring.domain.application
 
 import com.pickdsm.pickserverspring.common.annotation.Aggregate
 import java.time.LocalDate
-import java.util.UUID
+import java.util.*
 
 @Aggregate
 class Status(
 
-    val id: UUID,
+    val id: UUID = UUID(0, 0),
 
     val studentId: UUID,
 

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/classroom/Classroom.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/classroom/Classroom.kt
@@ -1,12 +1,12 @@
 package com.pickdsm.pickserverspring.domain.classroom
 
 import com.pickdsm.pickserverspring.common.annotation.Aggregate
-import java.util.UUID
+import java.util.*
 
 @Aggregate
 class Classroom(
 
-    val id: UUID,
+    val id: UUID = UUID(0, 0),
 
     val name: String,
 

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/classroom/ClassroomMovement.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/classroom/ClassroomMovement.kt
@@ -1,12 +1,12 @@
 package com.pickdsm.pickserverspring.domain.classroom
 
 import com.pickdsm.pickserverspring.common.annotation.Aggregate
-import java.util.UUID
+import java.util.*
 
 @Aggregate
 class ClassroomMovement(
 
-    val id: UUID,
+    val id: UUID = UUID(0, 0),
 
     val studentId: UUID,
 

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/club/Club.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/club/Club.kt
@@ -1,12 +1,12 @@
 package com.pickdsm.pickserverspring.domain.club
 
 import com.pickdsm.pickserverspring.common.annotation.Aggregate
-import java.util.UUID
+import java.util.*
 
 @Aggregate
 class Club(
 
-    val id: UUID,
+    val id: UUID = UUID(0, 0),
 
     val name: String,
 

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/selfstudydirector/SelfStudyDirector.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/selfstudydirector/SelfStudyDirector.kt
@@ -7,7 +7,7 @@ import java.util.*
 @Aggregate
 class SelfStudyDirector(
 
-    val id: UUID,
+    val id: UUID = UUID(0, 0),
 
     val floor: Int,
 

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/common/uuid/CustomUUIDGenerator.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/common/uuid/CustomUUIDGenerator.kt
@@ -7,8 +7,6 @@ import java.io.Serializable
 
 class CustomUUIDGenerator : IdentifierGenerator {
 
-    override fun generate(
-        session: SharedSessionContractImplementor,
-        entity: Any
-    ) : Serializable = UuidCreator.getTimeOrderedEpoch()
+    override fun generate(session: SharedSessionContractImplementor, entity: Any): Serializable =
+        UuidCreator.getTimeOrderedEpoch()
 }

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/common/uuid/CustomUUIDGenerator.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/common/uuid/CustomUUIDGenerator.kt
@@ -4,11 +4,11 @@ import com.github.f4b6a3.uuid.UuidCreator
 import org.hibernate.engine.spi.SharedSessionContractImplementor
 import org.hibernate.id.IdentifierGenerator
 import java.io.Serializable
-import java.util.UUID
 
-class UUIDv7Generator : IdentifierGenerator {
+class CustomUUIDGenerator : IdentifierGenerator {
 
     override fun generate(
-        session: SharedSessionContractImplementor, entity: Any
-    ): Serializable = UuidCreator.getTimeOrderedEpoch()
+        session: SharedSessionContractImplementor,
+        entity: Any
+    ) : Serializable = UuidCreator.getTimeOrderedEpoch()
 }

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/common/uuid/UUIDv7Generator.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/common/uuid/UUIDv7Generator.kt
@@ -1,0 +1,14 @@
+package com.pickdsm.pickserverspring.common.uuid
+
+import com.github.f4b6a3.uuid.UuidCreator
+import org.hibernate.engine.spi.SharedSessionContractImplementor
+import org.hibernate.id.IdentifierGenerator
+import java.io.Serializable
+import java.util.UUID
+
+class UUIDv7Generator : IdentifierGenerator {
+
+    override fun generate(
+        session: SharedSessionContractImplementor, entity: Any
+    ): Serializable = UuidCreator.getTimeOrderedEpoch()
+}

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/entity/ApplicationEntity.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/entity/ApplicationEntity.kt
@@ -2,7 +2,6 @@ package com.pickdsm.pickserverspring.domain.application.persistence.entity
 
 import com.pickdsm.pickserverspring.global.entity.BaseUUIDEntity
 import org.hibernate.annotations.ColumnDefault
-import java.io.Serializable
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.*
@@ -35,7 +34,7 @@ class ApplicationEntity(
     isStatus: Boolean,
 
     isPermission: Boolean,
-) : Serializable, BaseUUIDEntity(id) {
+) : BaseUUIDEntity(id) {
 
     @Column(columnDefinition = "TINYINT(1)", nullable = false)
     @ColumnDefault("0")

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/selfstudydirector/persistence/entity/SelfStudyDirectorEntity.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/selfstudydirector/persistence/entity/SelfStudyDirectorEntity.kt
@@ -7,6 +7,8 @@ import java.time.LocalDate
 import java.util.*
 import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
 import javax.persistence.Table
 
 @Table(name = "tbl_selfstudy_director")
@@ -24,6 +26,7 @@ class SelfStudyDirectorEntity(
     @Column(columnDefinition = "DATE", nullable = false)
     val date: LocalDate,
 
+    @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(12)", nullable = false)
     @ColumnDefault("''")
     val type: DirectorType,

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/global/entity/BaseUUIDEntity.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/global/entity/BaseUUIDEntity.kt
@@ -15,5 +15,5 @@ abstract class BaseUUIDEntity(
     @GeneratedValue(generator = "UUIDv7")
     @GenericGenerator(name = "UUIDv7", strategy = "com.pickdsm.pickserverspring.common.uuid.UUIDv7Generator")
     @Type(type = "uuid-char")
-    val id: UUID?,
+    val id: UUID,
 )

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/global/entity/BaseUUIDEntity.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/global/entity/BaseUUIDEntity.kt
@@ -13,7 +13,7 @@ abstract class BaseUUIDEntity(
 
     @Id
     @GeneratedValue(generator = "UUIDv7")
-    @GenericGenerator(name = "UUIDv7", strategy = "com.pickdsm.pickserverspring.common.uuid.UUIDv7Generator")
+    @GenericGenerator(name = "UUIDv7", strategy = "com.pickdsm.pickserverspring.common.uuid.CustomUUIDGenerator")
     @Type(type = "uuid-char")
     val id: UUID,
 )

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/global/entity/BaseUUIDEntity.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/global/entity/BaseUUIDEntity.kt
@@ -15,5 +15,5 @@ abstract class BaseUUIDEntity(
     @GeneratedValue(generator = "UUIDv7")
     @GenericGenerator(name = "UUIDv7", strategy = "com.pickdsm.pickserverspring.common.uuid.UUIDv7Generator")
     @Type(type = "uuid-char")
-    val id: UUID?
+    val id: UUID?,
 )

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/global/entity/BaseUUIDEntity.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/global/entity/BaseUUIDEntity.kt
@@ -1,8 +1,10 @@
 package com.pickdsm.pickserverspring.global.entity
 
-import com.github.f4b6a3.uuid.UuidCreator
-import java.util.UUID
+import org.hibernate.annotations.GenericGenerator
+import org.hibernate.annotations.Type
+import java.util.*
 import javax.persistence.Column
+import javax.persistence.GeneratedValue
 import javax.persistence.Id
 import javax.persistence.MappedSuperclass
 
@@ -10,6 +12,8 @@ import javax.persistence.MappedSuperclass
 abstract class BaseUUIDEntity(
 
     @Id
-    @Column(columnDefinition = "BINARY(16)", nullable = false)
-    val id: UUID = UuidCreator.getTimeOrderedEpoch(),
+    @GeneratedValue(generator = "UUIDv7")
+    @GenericGenerator(name = "UUIDv7", strategy = "com.pickdsm.pickserverspring.common.uuid.UUIDv7Generator")
+    @Type(type = "uuid-char")
+    val id: UUID?
 )


### PR DESCRIPTION
기존 v7 방식의 UUID를 Entity에서 주입하여 생성하고 있었지만, 그 방식에는 Aggregate에서 UUID(0, 0) or UUID.randomUUID()을 하게 되면 BaseUUIDEntity에서 주입하던 v7방식의 UUID가 주입되지 않는 현상이 발생했습니다. 그래서 Aggregate에서 UUID(0, 0)을 하게 되면 Insert Query가 날라갈 때 strategy를 직접 구현하여 UUIDv7 방식의 UUID가 생성되도록 수정하였습니다.