### PR TITLE
🔀 :: (#38) 교실이동 API 에러 수정

### DIFF
--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/classroom/usecase/ClassroomMovementUseCase.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/classroom/usecase/ClassroomMovementUseCase.kt
@@ -12,7 +12,6 @@ import com.pickdsm.pickserverspring.domain.teacher.spi.TimeQueryTeacherSpi
 import com.pickdsm.pickserverspring.domain.time.exception.TimeNotFoundException
 import com.pickdsm.pickserverspring.domain.user.spi.UserSpi
 import java.time.LocalDate
-import java.util.*
 
 @UseCase
 class ClassroomMovementUseCase(
@@ -23,8 +22,8 @@ class ClassroomMovementUseCase(
     private val statusCommandTeacherSpi: StatusCommandTeacherSpi,
 ) : ClassroomMovementApi {
 
-    override fun saveClassroomMovement(classroomId: UUID, request: DomainClassroomMovementRequest) {
-        val classroom = queryClassroomSpi.queryClassroomById(classroomId)
+    override fun saveClassroomMovement(request: DomainClassroomMovementRequest) {
+        val classroom = queryClassroomSpi.queryClassroomById(request.classroomId)
         val studentId = userSpi.getCurrentUserId()
         val timeList = timeQueryTeacherSpi.queryTime(LocalDate.now())
         val time = timeList.timeList.find { time -> time.period == request.period }

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/presentation/ApplicationWebAdapter.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/presentation/ApplicationWebAdapter.kt
@@ -34,8 +34,8 @@ class ApplicationWebAdapter(
     fun saveClassMovement(
         @PathVariable("classroom-id")
         classRoomId: UUID,
-        @Valid
         @RequestBody
+        @Valid
         request: ClassroomMovementRequest,
     ) {
         val domainRequest = DomainClassroomMovementRequest(


### PR DESCRIPTION
main 브랜치에서 교실이동 API쪽이 오버라이드 형식이 맞지 않아서 컴파일 오류를 일으키고 있었고 그 문제를 수정했습니다.