### PR TITLE
🔀 :: (#74) club entity에 clubId 추가

### DIFF
--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/club/Club.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/club/Club.kt
@@ -8,6 +8,8 @@ data class Club(
 
     val id: UUID = UUID.randomUUID(),
 
+    val clubId: UUID,
+
     val name: String,
 
     val headId: UUID,
@@ -26,7 +28,7 @@ data class Club(
 
     fun changeClubStudent(clubId: UUID, studentId: UUID, classroomId: UUID): Club {
         return copy(
-            id = clubId,
+            clubId = clubId,
             studentId = studentId,
             classroomId = classroomId,
         )

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/club/mapper/ClubMapperImpl.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/club/mapper/ClubMapperImpl.kt
@@ -18,6 +18,7 @@ class ClubMapperImpl(
 
         return ClubEntity(
             id = club.id,
+            clubId = club.clubId,
             name = club.name,
             teacherId = club.teacherId,
             studentId = club.studentId,
@@ -29,6 +30,7 @@ class ClubMapperImpl(
     override fun entityToDomain(clubEntity: ClubEntity): Club {
         return Club(
             id = clubEntity.id,
+            clubId = clubEntity.clubId,
             name = clubEntity.name,
             teacherId = clubEntity.teacherId,
             studentId = clubEntity.studentId,

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/club/persistence/adapter/ClubPersistenceAdapter.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/club/persistence/adapter/ClubPersistenceAdapter.kt
@@ -39,7 +39,7 @@ class ClubPersistenceAdapter(
     override fun queryClubByClubId(clubId: UUID): Club? =
         jpaQueryFactory
             .selectFrom(clubEntity)
-            .where(clubEntity.id.eq(clubId))
+            .where(clubEntity.clubId.eq(clubId))
             .fetchOne()
             ?.let(clubMapper::entityToDomain)
 
@@ -56,7 +56,7 @@ class ClubPersistenceAdapter(
         jpaQueryFactory
             .select(clubEntity.studentId)
             .from(clubEntity)
-            .where(clubEntity.id.eq(clubId))
+            .where(clubEntity.clubId.eq(clubId))
             .fetch()
 
     override fun queryClubStudentIdListByFloor(floor: Int?): List<UUID> =
@@ -71,7 +71,7 @@ class ClubPersistenceAdapter(
     override fun queryClubListByClubId(clubId: UUID): List<Club> =
         jpaQueryFactory
             .selectFrom(clubEntity)
-            .where(clubEntity.id.eq(clubId))
+            .where(clubEntity.clubId.eq(clubId))
             .fetch()
             .map(clubMapper::entityToDomain)
 

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/club/persistence/entity/ClubEntity.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/club/persistence/entity/ClubEntity.kt
@@ -17,6 +17,9 @@ class ClubEntity(
 
     override val id: UUID,
 
+    @Column(columnDefinition = "BINARY(16)", nullable = false)
+    val clubId: UUID,
+
     @Column(columnDefinition = "VARCHAR(255)", nullable = false)
     @ColumnDefault("''")
     val name: String,


### PR DESCRIPTION
기존의 clubEntity에서 한 동아리 당 학생 한 명만 소속되는 문제가 있어서 clubId 컬럼을 추가했습니다.

clubEntity의 pk인 id랑 clubId의 이름이 헷갈릴 수도 있을 것 같아서 더 좋은 컬럼 명이 있을까요