### PR TITLE
🔀 :: (#85) 메인페이지 학생 상태 수 조회 API 수정

### DIFF
--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/spi/QueryStatusSpi.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/spi/QueryStatusSpi.kt
@@ -28,4 +28,10 @@ interface QueryStatusSpi {
     fun queryStatusTypesByStudentIdAndEndPeriod(studentId: UUID, period: Int): List<StatusType>
 
     fun queryMovementStatusListByTodayAndClassroomId(classroomId: UUID): List<Status>
+
+    fun queryPicnicApplicationCountByToday(): Int
+
+    fun queryMovementCountByFloorAndToday(floor: Int): Int
+
+    fun queryPicnicCountByToday(): Int
 }

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/spi/QueryStatusSpi.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/spi/QueryStatusSpi.kt
@@ -29,9 +29,9 @@ interface QueryStatusSpi {
 
     fun queryMovementStatusListByTodayAndClassroomId(classroomId: UUID): List<Status>
 
-    fun queryPicnicApplicationCountByToday(): Int
+    fun queryPicnicApplicationStatusSizeByToday(): Int
 
-    fun queryMovementCountByFloorAndToday(floor: Int): Int
+    fun queryMovementStatusSizeByFloorAndToday(floor: Int): Int
 
-    fun queryPicnicCountByToday(): Int
+    fun queryPicnicStatusSizeByToday(): Int
 }

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/spi/QueryStatusSpi.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/spi/QueryStatusSpi.kt
@@ -29,9 +29,9 @@ interface QueryStatusSpi {
 
     fun queryMovementStatusListByTodayAndClassroomId(classroomId: UUID): List<Status>
 
-    fun queryPicnicApplicationStatusIdByToday(): List<UUID>
+    fun queryPicnicApplicationCountByToday(): Int
 
-    fun queryMovementStatusIdByFloorAndToday(floor: Int): List<UUID>
+    fun queryMovementCountByFloorAndToday(floor: Int): Int
 
-    fun queryPicnicStatusIdByToday(): List<UUID>
+    fun queryPicnicCountByToday(): Int
 }

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/spi/QueryStatusSpi.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/spi/QueryStatusSpi.kt
@@ -29,9 +29,9 @@ interface QueryStatusSpi {
 
     fun queryMovementStatusListByTodayAndClassroomId(classroomId: UUID): List<Status>
 
-    fun queryPicnicApplicationCountByToday(): Int
+    fun queryPicnicApplicationStatusIdByToday(): List<UUID>
 
-    fun queryMovementCountByFloorAndToday(floor: Int): Int
+    fun queryMovementStatusIdByFloorAndToday(floor: Int): List<UUID>
 
-    fun queryPicnicCountByToday(): Int
+    fun queryPicnicStatusIdByToday(): List<UUID>
 }

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
@@ -63,9 +63,9 @@ class TeacherUseCase(
             ?: throw FloorNotFoundException
 
         return QueryStudentStatusCountResponse(
-            picnic = queryStatusSpi.queryPicnicCountByToday(),
-            application = queryStatusSpi.queryPicnicApplicationCountByToday(),
-            classroomMovement = queryStatusSpi.queryMovementCountByFloorAndToday(teacherResponsibleFloor),
+            picnic = queryStatusSpi.queryPicnicStatusSizeByToday(),
+            application = queryStatusSpi.queryPicnicApplicationStatusSizeByToday(),
+            classroomMovement = queryStatusSpi.queryMovementStatusSizeByFloorAndToday(teacherResponsibleFloor),
         )
     }
 

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
@@ -63,9 +63,9 @@ class TeacherUseCase(
             ?: throw FloorNotFoundException
 
         return QueryStudentStatusCountResponse(
-            picnic = queryStatusSpi.queryPicnicCountByToday(),
-            application = queryStatusSpi.queryPicnicApplicationCountByToday(),
-            classroomMovement = queryStatusSpi.queryMovementCountByFloorAndToday(teacherResponsibleFloor),
+            picnic = queryStatusSpi.queryPicnicStatusIdByToday().count(),
+            application = queryStatusSpi.queryPicnicApplicationStatusIdByToday().count(),
+            classroomMovement = queryStatusSpi.queryMovementStatusIdByFloorAndToday(teacherResponsibleFloor).count(),
         )
     }
 

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
@@ -60,7 +60,7 @@ class TeacherUseCase(
 
     override fun getStudentStatusCount(): QueryStudentStatusCountResponse {
         val teacherResponsibleFloor = querySelfStudyDirectorSpi.queryResponsibleFloorByTeacherId(userSpi.getCurrentUserId())
-                ?: throw FloorNotFoundException
+            ?: throw FloorNotFoundException
 
         return QueryStudentStatusCountResponse(
             picnic = queryStatusSpi.queryPicnicCountByToday(),

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
@@ -6,7 +6,9 @@ import com.pickdsm.pickserverspring.domain.application.exception.StatusNotFoundE
 import com.pickdsm.pickserverspring.domain.application.spi.QueryApplicationSpi
 import com.pickdsm.pickserverspring.domain.application.spi.QueryStatusSpi
 import com.pickdsm.pickserverspring.domain.classroom.exception.ClassroomNotFoundException
+import com.pickdsm.pickserverspring.domain.classroom.exception.FloorNotFoundException
 import com.pickdsm.pickserverspring.domain.classroom.spi.QueryClassroomSpi
+import com.pickdsm.pickserverspring.domain.selfstudydirector.spi.QuerySelfStudyDirectorSpi
 import com.pickdsm.pickserverspring.domain.teacher.api.TeacherApi
 import com.pickdsm.pickserverspring.domain.teacher.api.dto.request.DomainComebackStudentRequest
 import com.pickdsm.pickserverspring.domain.teacher.api.dto.request.DomainUpdateStudentStatusRequest
@@ -28,6 +30,7 @@ class TeacherUseCase(
     private val timeQueryTeacherSpi: TimeQueryTeacherSpi,
     private val queryApplicationSpi: QueryApplicationSpi,
     private val queryClassroomSpi: QueryClassroomSpi,
+    private val querySelfStudyDirectorSpi: QuerySelfStudyDirectorSpi,
     private val queryStatusSpi: QueryStatusSpi,
 ) : TeacherApi {
 
@@ -56,20 +59,13 @@ class TeacherUseCase(
     }
 
     override fun getStudentStatusCount(): QueryStudentStatusCountResponse {
-        val today = LocalDate.now()
-        val status = queryStatusSpi.queryPicnicStudentInfoListByToday(today)
-        val picnicCount = status.count()
-
-        val classroomMovement = queryStatusSpi.queryMovementStudentInfoListByToday(today)
-        val classroomMovementCount = classroomMovement.count()
-
-        val application = queryApplicationSpi.queryPicnicApplicationListByToday(today)
-        val applicationCount = application.count()
+        val teacherResponsibleFloor = querySelfStudyDirectorSpi.queryResponsibleFloorByTeacherId(userSpi.getCurrentUserId())
+                ?: throw FloorNotFoundException
 
         return QueryStudentStatusCountResponse(
-            picnic = picnicCount,
-            classroomMovement = classroomMovementCount,
-            application = applicationCount,
+            picnic = queryStatusSpi.queryPicnicCountByToday(),
+            application = queryStatusSpi.queryPicnicApplicationCountByToday(),
+            classroomMovement = queryStatusSpi.queryMovementCountByFloorAndToday(teacherResponsibleFloor),
         )
     }
 

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
@@ -63,9 +63,9 @@ class TeacherUseCase(
             ?: throw FloorNotFoundException
 
         return QueryStudentStatusCountResponse(
-            picnic = queryStatusSpi.queryPicnicStatusIdByToday().count(),
-            application = queryStatusSpi.queryPicnicApplicationStatusIdByToday().count(),
-            classroomMovement = queryStatusSpi.queryMovementStatusIdByFloorAndToday(teacherResponsibleFloor).count(),
+            picnic = queryStatusSpi.queryPicnicCountByToday(),
+            application = queryStatusSpi.queryPicnicApplicationCountByToday(),
+            classroomMovement = queryStatusSpi.queryMovementCountByFloorAndToday(teacherResponsibleFloor),
         )
     }
 

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/StatusPersistenceAdapter.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/StatusPersistenceAdapter.kt
@@ -143,7 +143,7 @@ class StatusPersistenceAdapter(
             .fetch()
             .map(statusMapper::entityToDomain)
 
-    override fun queryPicnicApplicationStatusIdByToday(): List<UUID> =
+    override fun queryPicnicApplicationCountByToday(): Int =
         jpaQueryFactory
             .select(statusEntity.id)
             .from(statusEntity)
@@ -151,9 +151,9 @@ class StatusPersistenceAdapter(
                 statusEntity.date.eq(LocalDate.now()),
                 statusEntity.type.eq(StatusType.AWAIT),
             )
-            .fetch()
+            .fetch().size
 
-    override fun queryMovementStatusIdByFloorAndToday(floor: Int): List<UUID> =
+    override fun queryMovementCountByFloorAndToday(floor: Int): Int =
         jpaQueryFactory
             .select(statusEntity.id)
             .from(statusEntity)
@@ -166,9 +166,9 @@ class StatusPersistenceAdapter(
                 statusEntity.type.eq(StatusType.MOVEMENT),
                 classroomEntity.floor.eq(floor),
             )
-            .fetch()
+            .fetch().size
 
-    override fun queryPicnicStatusIdByToday(): List<UUID> =
+    override fun queryPicnicCountByToday(): Int =
         jpaQueryFactory
             .select(statusEntity.id)
             .from(statusEntity)
@@ -176,5 +176,5 @@ class StatusPersistenceAdapter(
                 statusEntity.date.eq(LocalDate.now()),
                 statusEntity.type.eq(StatusType.PICNIC),
             )
-            .fetch()
+            .fetch().size
 }

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/StatusPersistenceAdapter.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/StatusPersistenceAdapter.kt
@@ -143,7 +143,7 @@ class StatusPersistenceAdapter(
             .fetch()
             .map(statusMapper::entityToDomain)
 
-    override fun queryPicnicApplicationCountByToday(): Int =
+    override fun queryPicnicApplicationStatusSizeByToday(): Int =
         jpaQueryFactory
             .select(statusEntity.id)
             .from(statusEntity)
@@ -153,7 +153,7 @@ class StatusPersistenceAdapter(
             )
             .fetch().size
 
-    override fun queryMovementCountByFloorAndToday(floor: Int): Int =
+    override fun queryMovementStatusSizeByFloorAndToday(floor: Int): Int =
         jpaQueryFactory
             .select(statusEntity.id)
             .from(statusEntity)
@@ -168,7 +168,7 @@ class StatusPersistenceAdapter(
             )
             .fetch().size
 
-    override fun queryPicnicCountByToday(): Int =
+    override fun queryPicnicStatusSizeByToday(): Int =
         jpaQueryFactory
             .select(statusEntity.id)
             .from(statusEntity)

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/StatusPersistenceAdapter.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/StatusPersistenceAdapter.kt
@@ -142,4 +142,39 @@ class StatusPersistenceAdapter(
             .where(statusEntity.date.eq(LocalDate.now()))
             .fetch()
             .map(statusMapper::entityToDomain)
+
+    override fun queryPicnicApplicationCountByToday(): Int =
+            jpaQueryFactory
+                .select(statusEntity.count().intValue())
+                .from(statusEntity)
+                .where(
+                    statusEntity.date.eq(LocalDate.now()),
+                    statusEntity.type.eq(StatusType.AWAIT),
+                )
+                .fetchFirst()
+
+    override fun queryMovementCountByFloorAndToday(floor: Int): Int =
+            jpaQueryFactory
+                .select(statusEntity.count().intValue())
+                .from(statusEntity)
+                .innerJoin(classroomMovementEntity)
+                .on(statusEntity.id.eq(classroomMovementEntity.statusEntity.id))
+                .innerJoin(classroomEntity)
+                .on(classroomMovementEntity.classroomEntity.id.eq(classroomEntity.id))
+                .where(
+                    statusEntity.date.eq(LocalDate.now()),
+                    statusEntity.type.eq(StatusType.MOVEMENT),
+                    classroomEntity.floor.eq(floor),
+                )
+                .fetchFirst()
+
+    override fun queryPicnicCountByToday(): Int =
+            jpaQueryFactory
+                .select(statusEntity.count().intValue())
+                .from(statusEntity)
+                .where(
+                    statusEntity.date.eq(LocalDate.now()),
+                    statusEntity.type.eq(StatusType.PICNIC),
+                )
+                .fetchFirst()
 }

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/StatusPersistenceAdapter.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/StatusPersistenceAdapter.kt
@@ -144,37 +144,37 @@ class StatusPersistenceAdapter(
             .map(statusMapper::entityToDomain)
 
     override fun queryPicnicApplicationCountByToday(): Int =
-            jpaQueryFactory
-                .select(statusEntity.count().intValue())
-                .from(statusEntity)
-                .where(
-                    statusEntity.date.eq(LocalDate.now()),
-                    statusEntity.type.eq(StatusType.AWAIT),
-                )
-                .fetchFirst()
+        jpaQueryFactory
+            .select(statusEntity.count().intValue())
+            .from(statusEntity)
+            .where(
+                statusEntity.date.eq(LocalDate.now()),
+                statusEntity.type.eq(StatusType.AWAIT),
+            )
+            .fetchFirst()
 
     override fun queryMovementCountByFloorAndToday(floor: Int): Int =
-            jpaQueryFactory
-                .select(statusEntity.count().intValue())
-                .from(statusEntity)
-                .innerJoin(classroomMovementEntity)
-                .on(statusEntity.id.eq(classroomMovementEntity.statusEntity.id))
-                .innerJoin(classroomEntity)
-                .on(classroomMovementEntity.classroomEntity.id.eq(classroomEntity.id))
-                .where(
-                    statusEntity.date.eq(LocalDate.now()),
-                    statusEntity.type.eq(StatusType.MOVEMENT),
-                    classroomEntity.floor.eq(floor),
-                )
-                .fetchFirst()
+        jpaQueryFactory
+            .select(statusEntity.count().intValue())
+            .from(statusEntity)
+            .innerJoin(classroomMovementEntity)
+            .on(statusEntity.id.eq(classroomMovementEntity.statusEntity.id))
+            .innerJoin(classroomEntity)
+            .on(classroomMovementEntity.classroomEntity.id.eq(classroomEntity.id))
+            .where(
+                statusEntity.date.eq(LocalDate.now()),
+                statusEntity.type.eq(StatusType.MOVEMENT),
+                classroomEntity.floor.eq(floor),
+            )
+            .fetchFirst()
 
     override fun queryPicnicCountByToday(): Int =
-            jpaQueryFactory
-                .select(statusEntity.count().intValue())
-                .from(statusEntity)
-                .where(
-                    statusEntity.date.eq(LocalDate.now()),
-                    statusEntity.type.eq(StatusType.PICNIC),
-                )
-                .fetchFirst()
+        jpaQueryFactory
+            .select(statusEntity.count().intValue())
+            .from(statusEntity)
+            .where(
+                statusEntity.date.eq(LocalDate.now()),
+                statusEntity.type.eq(StatusType.PICNIC),
+            )
+            .fetchFirst()
 }

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/StatusPersistenceAdapter.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/StatusPersistenceAdapter.kt
@@ -143,19 +143,19 @@ class StatusPersistenceAdapter(
             .fetch()
             .map(statusMapper::entityToDomain)
 
-    override fun queryPicnicApplicationCountByToday(): Int =
+    override fun queryPicnicApplicationStatusIdByToday(): List<UUID> =
         jpaQueryFactory
-            .select(statusEntity.count().intValue())
+            .select(statusEntity.id)
             .from(statusEntity)
             .where(
                 statusEntity.date.eq(LocalDate.now()),
                 statusEntity.type.eq(StatusType.AWAIT),
             )
-            .fetchFirst()
+            .fetch()
 
-    override fun queryMovementCountByFloorAndToday(floor: Int): Int =
+    override fun queryMovementStatusIdByFloorAndToday(floor: Int): List<UUID> =
         jpaQueryFactory
-            .select(statusEntity.count().intValue())
+            .select(statusEntity.id)
             .from(statusEntity)
             .innerJoin(classroomMovementEntity)
             .on(statusEntity.id.eq(classroomMovementEntity.statusEntity.id))
@@ -166,15 +166,15 @@ class StatusPersistenceAdapter(
                 statusEntity.type.eq(StatusType.MOVEMENT),
                 classroomEntity.floor.eq(floor),
             )
-            .fetchFirst()
+            .fetch()
 
-    override fun queryPicnicCountByToday(): Int =
+    override fun queryPicnicStatusIdByToday(): List<UUID> =
         jpaQueryFactory
-            .select(statusEntity.count().intValue())
+            .select(statusEntity.id)
             .from(statusEntity)
             .where(
                 statusEntity.date.eq(LocalDate.now()),
                 statusEntity.type.eq(StatusType.PICNIC),
             )
-            .fetchFirst()
+            .fetch()
 }


### PR DESCRIPTION
기존 API : 담당 선생님(2층) -> 2층에서 이동한 학생 수를 가져와야 하지만 그 처리가 안 되어 있어서 그 처리를 했습니다.
또한 count 쿼리로 가져오지 않고 fetch로 가져온 뒤 코틀린의 count 메소드를 사용하던 부분을 count 쿼리로 변경했습니다.