### PR TITLE
🔀 :: (#25) 담당 층별 교실 리스트 에러 코드 수정

### DIFF
--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/classroom/usecase/ClassroomUseCase.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/classroom/usecase/ClassroomUseCase.kt
@@ -79,8 +79,12 @@ class ClassroomUseCase(
 
     override fun queryResponsibleClassroomList(): QueryResponsibleClassroomList {
         val teacherId = userSpi.getCurrentUserId()
-        val floor = querySelfStudyDirectorSpi.queryResponsibleFloorByTeacherId(teacherId)
-            ?: throw FloorNotFoundException
+        val typeId = queryTypeSpi.queryTypeIdByDate(LocalDate.now())
+            ?: throw TypeNotFoundException
+        val floor = querySelfStudyDirectorSpi.queryResponsibleFloorByTeacherIdAndTypeId(
+            teacherId = teacherId,
+            typeId = typeId,
+        ) ?: throw FloorNotFoundException
         val todayType = queryTypeSpi.queryDirectorTypeByDate(LocalDate.now())
             ?: DirectorType.SELF_STUDY
         val classrooms = mutableListOf<ResponsibleClassroomElement>()

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/selfstudydirector/spi/QuerySelfStudyDirectorSpi.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/selfstudydirector/spi/QuerySelfStudyDirectorSpi.kt
@@ -10,6 +10,8 @@ interface QuerySelfStudyDirectorSpi {
 
     fun queryResponsibleFloorByTeacherId(teacherId: UUID): Int?
 
+    fun queryResponsibleFloorByTeacherIdAndTypeId(teacherId: UUID, typeId: UUID): Int?
+
     fun queryAllSelfStudyDirectorByTeacherIdAndDate(teacherId: UUID, date: LocalDate): List<SelfStudyDirector>
 
     fun querySelfStudyDirectorByTeacherId(teacherId: UUID): SelfStudyDirector

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/selfstudydirector/spi/QueryTypeSpi.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/selfstudydirector/spi/QueryTypeSpi.kt
@@ -16,4 +16,6 @@ interface QueryTypeSpi {
     fun queryDirectorTypeByDate(date: LocalDate): DirectorType?
 
     fun queryTypeByDate(date: LocalDate): Type?
+
+    fun queryTypeIdByDate(date: LocalDate): UUID?
 }

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/selfstudydirector/persistence/adapter/SelfStudyDirectorPersistenceAdapter.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/selfstudydirector/persistence/adapter/SelfStudyDirectorPersistenceAdapter.kt
@@ -40,6 +40,17 @@ class SelfStudyDirectorPersistenceAdapter(
             .where(selfStudyDirectorEntity.teacherId.eq(teacherId))
             .fetchOne()
 
+    override fun queryResponsibleFloorByTeacherIdAndTypeId(teacherId: UUID, typeId: UUID): Int? =
+        jpaQueryFactory
+            .select(selfStudyDirectorEntity.floor)
+            .from(selfStudyDirectorEntity)
+            .innerJoin(selfStudyDirectorEntity.typeEntity, typeEntity)
+            .where(
+                selfStudyDirectorEntity.teacherId.eq(teacherId),
+                typeEntity.id.eq(typeId),
+            )
+            .fetchOne()
+
     override fun queryAllSelfStudyDirectorByTeacherIdAndDate(
         teacherId: UUID,
         date: LocalDate,

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/selfstudydirector/persistence/adapter/TypePersistenceAdapter.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/selfstudydirector/persistence/adapter/TypePersistenceAdapter.kt
@@ -51,6 +51,13 @@ class TypePersistenceAdapter(
             .fetchOne()
             ?.let(typeMapper::entityToDomain)
 
+    override fun queryTypeIdByDate(date: LocalDate): UUID? =
+        jpaQueryFactory
+            .select(typeEntity.id)
+            .from(typeEntity)
+            .where(typeEntity.date.eq(date))
+            .fetchOne()
+
     override fun saveType(type: Type) {
         val typeEntity = typeMapper.domainToEntity(type)
         typeRepository.save(typeEntity)


### PR DESCRIPTION
teacherId로만 비교해서 담당 층별 교실 리스트를 불러올 수 없어서 로그인이 안되는 문제가 발생했습니다. typeId도 비교하는 것을 추가했습니다.