### PR TITLE
🔀 :: (#96) 방과후일 때는 같은 교실이동에 관한 처리 안 하도록 수정

### DIFF
--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/classroom/usecase/ClassroomMovementUseCase.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/classroom/usecase/ClassroomMovementUseCase.kt
@@ -73,17 +73,6 @@ class ClassroomMovementUseCase(
             ?: throw TypeNotFoundException
 
         when (todayType) {
-            DirectorType.AFTER_SCHOOL -> {
-                val userAfterSchoolClassroomId = queryAfterSchoolSpi.queryAfterSchoolClassroomIdByStudentId(student.id)
-                    ?: throw AfterSchoolNotFoundException
-                val userAfterSchoolClassroom = getClassroomByClassroomId(userAfterSchoolClassroomId)
-
-                checkIsMovementMyClassroom(
-                    requestMovementClassroom = classroom,
-                    existingClassroom = userAfterSchoolClassroom,
-                )
-            }
-
             DirectorType.TUE_CLUB, DirectorType.FRI_CLUB -> {
                 val userClubClassroomId = queryClubSpi.queryClubClassroomIdByStudentId(student.id)
                     ?: throw ClubNotFoundException
@@ -101,6 +90,8 @@ class ClassroomMovementUseCase(
                     throw CannotMovementMyClassroom
                 }
             }
+
+            else -> throw TypeNotFoundException
         }
 
         checkIsStatusPicnic(statusTypes)


### PR DESCRIPTION
현재 방과후는 창조실 밖에 사용하지 않음
그것과 관련된 명단 X -> DB에 값 존재 X -> AfterSchoolNotFound로 인해 교실이동 불가능

그렇기 때문에 방과후 떄는 같은 교실 이동에 관한 처리를 안 하도록 수정했습니다