### PR TITLE
🔀 :: (#42) 학생 복귀시 출석으로 변경되지 않도록 수정

### DIFF
--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/Status.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/Status.kt
@@ -21,9 +21,8 @@ data class Status(
 
     val type: StatusType,
 ) {
-    fun changeStatusToAttendance(teacherId: UUID, endPeriod: Int): Status {
+    fun changeStatusToAttendance(endPeriod: Int): Status {
         return copy(
-            teacherId = teacherId,
             endPeriod = endPeriod,
         )
     }

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/Status.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/Status.kt
@@ -25,7 +25,6 @@ data class Status(
         return copy(
             teacherId = teacherId,
             endPeriod = endPeriod,
-            type = StatusType.ATTENDANCE,
         )
     }
 

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
@@ -70,14 +70,11 @@ class TeacherUseCase(
     }
 
     override fun comebackStudent(request: DomainComebackStudentRequest) {
-        val teacherId = userSpi.getCurrentUserId()
-        println(queryStatusSpi.queryPicnicStudentByStudentIdAndToday(request.studentId))
-        println(request.studentId)
         val picnicStudent = queryStatusSpi.queryPicnicStudentByStudentIdAndToday(request.studentId)
             ?: throw StatusNotFoundException
         statusCommandTeacherSpi.saveStatus(
             picnicStudent.changeStatusToAttendance(
-                endPeriod = request.endPeriod
+                endPeriod = request.endPeriod,
             ),
         )
     }

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
@@ -71,13 +71,13 @@ class TeacherUseCase(
 
     override fun comebackStudent(request: DomainComebackStudentRequest) {
         val teacherId = userSpi.getCurrentUserId()
+        println(queryStatusSpi.queryPicnicStudentByStudentIdAndToday(request.studentId))
+        println(request.studentId)
         val picnicStudent = queryStatusSpi.queryPicnicStudentByStudentIdAndToday(request.studentId)
             ?: throw StatusNotFoundException
-
         statusCommandTeacherSpi.saveStatus(
             picnicStudent.changeStatusToAttendance(
-                teacherId = teacherId,
-                endPeriod = request.endPeriod,
+                endPeriod = request.endPeriod
             ),
         )
     }

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/StatusPersistenceAdapter.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/StatusPersistenceAdapter.kt
@@ -98,6 +98,7 @@ class StatusPersistenceAdapter(
             .where(
                 statusEntity.studentId.eq(studentId),
                 statusEntity.type.eq(StatusType.PICNIC),
+                statusEntity.date.eq(LocalDate.now()),
             )
             .fetchFirst()
             ?.let(statusMapper::entityToDomain)


### PR DESCRIPTION
학생 복귀버튼을 눌렀을 때 출석으로 상태를 바꿔버려서 외출 상태가 남지 않고 있는 걸 외출 복귀가 끝나면 endPeriod를 바꾸는 것으로 변경했습니다