### PR TITLE
🔀 :: (#115) 학생 상태 수 조회 API 자습감독 선생님 아닐 때 처리

### DIFF
--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
@@ -62,12 +62,10 @@ class TeacherUseCase(
 
     override fun getStudentStatusCount(): QueryStudentStatusCountResponse {
         val teacherResponsibleFloor = querySelfStudyDirectorSpi.queryResponsibleFloorByTeacherIdAndToday(userSpi.getCurrentUserId())
-            ?: throw FloorNotFoundException
-
         return QueryStudentStatusCountResponse(
             picnic = queryStatusSpi.queryPicnicStatusSizeByToday(),
             application = queryStatusSpi.queryPicnicApplicationStatusSizeByToday(),
-            classroomMovement = queryStatusSpi.queryMovementStatusSizeByFloorAndToday(teacherResponsibleFloor),
+            classroomMovement = queryStatusSpi.queryMovementStatusSizeByFloorAndToday(teacherResponsibleFloor ?: 2),
         )
     }
 


### PR DESCRIPTION
어드민 메인페이지 학생 상태 수 조회 API에서 자습감독 선생님이 아닐 경우 FloorNotFound 에러를 띄우게 되고 그러면 다른 부분도 조회가 되지 않기 떄문에 자습감독 선생님이 아닐 경우 2층으로 띄워주기로 수정했습니다.