### PR TITLE
🔀 :: (#155) 학생 복귀 여부 칼럼 추가

### DIFF
--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/Application.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/Application.kt
@@ -11,4 +11,12 @@ data class Application(
     val reason: String,
 
     val statusId: UUID,
-)
+
+    val isReturn: Boolean,
+) {
+    fun changeStatusToAttendance(isReturn: Boolean): Application {
+        return copy(
+            isReturn = isReturn,
+        )
+    }
+}

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/usecase/ApplicationUseCase.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/usecase/ApplicationUseCase.kt
@@ -78,6 +78,7 @@ class ApplicationUseCase(
             Application(
                 reason = request.reason,
                 statusId = saveStatusId,
+                isReturn = false,
             ),
         )
     }
@@ -444,6 +445,7 @@ class ApplicationUseCase(
                 Application(
                     reason = request.reason,
                     statusId = saveStatusId,
+                    isReturn = false,
                 ),
             )
         }

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
@@ -78,12 +78,12 @@ class TeacherUseCase(
             ?: throw StatusNotFoundException
 
         val picnicApplication = queryApplicationSpi.queryApplicationByStudentIdAndStatusId(picnicStudent.studentId, picnicStudent.id)
-            ?: throw ApplicationNotFoundException;
+            ?: throw ApplicationNotFoundException
 
         commandApplicationSpi.saveApplication(
             picnicApplication.changeStatusToAttendance(
                 isReturn = true,
-            )
+            ),
         )
 
         statusCommandTeacherSpi.saveStatus(

--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/teacher/usecase/TeacherUseCase.kt
@@ -2,7 +2,10 @@ package com.pickdsm.pickserverspring.domain.teacher.usecase
 
 import com.pickdsm.pickserverspring.common.annotation.UseCase
 import com.pickdsm.pickserverspring.domain.application.Status
+import com.pickdsm.pickserverspring.domain.application.exception.ApplicationNotFoundException
 import com.pickdsm.pickserverspring.domain.application.exception.StatusNotFoundException
+import com.pickdsm.pickserverspring.domain.application.spi.CommandApplicationSpi
+import com.pickdsm.pickserverspring.domain.application.spi.QueryApplicationSpi
 import com.pickdsm.pickserverspring.domain.application.spi.QueryStatusSpi
 import com.pickdsm.pickserverspring.domain.classroom.exception.ClassroomNotFoundException
 import com.pickdsm.pickserverspring.domain.classroom.exception.FloorNotFoundException
@@ -33,7 +36,8 @@ class TeacherUseCase(
     private val queryClassroomSpi: QueryClassroomSpi,
     private val querySelfStudyDirectorSpi: QuerySelfStudyDirectorSpi,
     private val queryStatusSpi: QueryStatusSpi,
-    private val queryTypeSpi: QueryTypeSpi,
+    private val commandApplicationSpi: CommandApplicationSpi,
+    private val queryApplicationSpi: QueryApplicationSpi,
 ) : TeacherApi {
 
     override fun updateStudentStatus(request: DomainUpdateStudentStatusRequest) {
@@ -72,6 +76,16 @@ class TeacherUseCase(
     override fun comebackStudent(request: DomainComebackStudentRequest) {
         val picnicStudent = queryStatusSpi.queryPicnicStudentByStudentIdAndToday(request.studentId)
             ?: throw StatusNotFoundException
+
+        val picnicApplication = queryApplicationSpi.queryApplicationByStudentIdAndStatusId(picnicStudent.studentId, picnicStudent.id)
+            ?: throw ApplicationNotFoundException;
+
+        commandApplicationSpi.saveApplication(
+            picnicApplication.changeStatusToAttendance(
+                isReturn = true,
+            )
+        )
+
         statusCommandTeacherSpi.saveStatus(
             picnicStudent.changeStatusToAttendance(
                 endPeriod = request.endPeriod,

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/mapper/ApplicationMapperImpl.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/mapper/ApplicationMapperImpl.kt
@@ -20,6 +20,7 @@ class ApplicationMapperImpl(
             id = application.id,
             reason = application.reason,
             statusEntity = statusEntity,
+            isReturn = application.isReturn,
         )
     }
 
@@ -28,6 +29,7 @@ class ApplicationMapperImpl(
             id = applicationEntity.id,
             reason = applicationEntity.reason,
             statusId = applicationEntity.statusEntity.id,
+            isReturn = applicationEntity.isReturn,
         )
     }
 }

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/StatusPersistenceAdapter.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/StatusPersistenceAdapter.kt
@@ -4,6 +4,7 @@ import com.pickdsm.pickserverspring.domain.application.Status
 import com.pickdsm.pickserverspring.domain.application.StatusType
 import com.pickdsm.pickserverspring.domain.application.mapper.StatusMapper
 import com.pickdsm.pickserverspring.domain.application.persistence.StatusRepository
+import com.pickdsm.pickserverspring.domain.application.persistence.entity.QApplicationEntity.applicationEntity
 import com.pickdsm.pickserverspring.domain.application.persistence.entity.QStatusEntity.statusEntity
 import com.pickdsm.pickserverspring.domain.application.spi.StatusSpi
 import com.pickdsm.pickserverspring.domain.classroom.persistence.entity.QClassroomEntity.classroomEntity
@@ -51,9 +52,12 @@ class StatusPersistenceAdapter(
     override fun queryPicnicStudentInfoListByToday(date: LocalDate): List<Status> =
         jpaQueryFactory
             .selectFrom(statusEntity)
+            .join(applicationEntity)
+            .on(statusEntity.id.eq(applicationEntity.statusEntity.id))
             .where(
                 statusEntity.date.eq(date),
                 statusEntity.type.eq(StatusType.PICNIC),
+                applicationEntity.isReturn.eq(false),
             )
             .fetch()
             .map(statusMapper::entityToDomain)

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/entity/ApplicationEntity.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/entity/ApplicationEntity.kt
@@ -24,4 +24,8 @@ class ApplicationEntity(
     @JoinColumn(name = "status_id", columnDefinition = "BINARY(16)", nullable = false)
     val statusEntity: StatusEntity,
 
+    @Column(columnDefinition = "TINYINT(1)", nullable = false)
+    @ColumnDefault("false")
+    val isReturn: Boolean,
+
 ) : BaseUUIDEntity(id)


### PR DESCRIPTION
- 기존의 외출 복귀 시 application 테이블에서 값을 삭제하였지만 외출자 리스트를 보는 기능을 추가해달라는 요구사항에 맞춰 isReturn 칼럼을 추가하고 외출신청, 외출 복귀, 외출한 학생 리스트 API를 수정했습니다.