### PR TITLE
🔀 :: (#188) 외출 복귀 시 외출증 조회 안되게 수정

### DIFF
--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/ApplicationPersistenceAdapter.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/ApplicationPersistenceAdapter.kt
@@ -38,7 +38,7 @@ class ApplicationPersistenceAdapter(
             .where(
                 statusEntity.studentId.eq(studentId),
                 applicationEntity.isReturn.eq(false),
-                )
+            )
             .fetchFirst()
             ?.let(applicationMapper::entityToDomain)
 }

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/ApplicationPersistenceAdapter.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/ApplicationPersistenceAdapter.kt
@@ -35,7 +35,10 @@ class ApplicationPersistenceAdapter(
             .selectFrom(applicationEntity)
             .innerJoin(applicationEntity.statusEntity, statusEntity)
             .on(applicationEntity.statusEntity.id.eq(statusId))
-            .where(statusEntity.studentId.eq(studentId))
+            .where(
+                statusEntity.studentId.eq(studentId),
+                applicationEntity.isReturn.eq(false),
+                )
             .fetchFirst()
             ?.let(applicationMapper::entityToDomain)
 }

--- a/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/StatusPersistenceAdapter.kt
+++ b/pick-infrastructure/src/main/kotlin/com/pickdsm/pickserverspring/domain/application/persistence/adapter/StatusPersistenceAdapter.kt
@@ -99,10 +99,13 @@ class StatusPersistenceAdapter(
     override fun queryPicnicStudentByStudentIdAndToday(studentId: UUID): Status? =
         jpaQueryFactory
             .selectFrom(statusEntity)
+            .join(applicationEntity)
+            .on(statusEntity.id.eq(applicationEntity.statusEntity.id))
             .where(
                 statusEntity.studentId.eq(studentId),
                 statusEntity.type.eq(StatusType.PICNIC),
                 statusEntity.date.eq(LocalDate.now()),
+                applicationEntity.isReturn.eq(false),
             )
             .fetchFirst()
             ?.let(statusMapper::entityToDomain)


### PR DESCRIPTION
- 현재 외출에서 복귀해도 외출증이 계속 조회되는 문제를 쿼리문에 isReturn(복귀여부)의 값이 false인 것만 조회하도록 쿼리문을 추가해 수정하였습니다.