### PR TITLE
🔀 :: (#202) 교실 이동 API 수정

### DIFF
--- a/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/classroom/usecase/ClassroomMovementUseCase.kt
+++ b/pick-application/src/main/kotlin/com/pickdsm/pickserverspring/domain/classroom/usecase/ClassroomMovementUseCase.kt
@@ -102,7 +102,7 @@ class ClassroomMovementUseCase(
             }
         }
 
-        checkIsStatusPicnic(statusTypes)
+        checkIsStatusPicnicOrAwait(statusTypes)
         checkIsWeekends()
 
         when (queryClassroomMovementSpi.existClassroomMovementByStudentId(student.id)) {
@@ -152,9 +152,9 @@ class ClassroomMovementUseCase(
         }
     }
 
-    private fun checkIsStatusPicnic(statusTypes: List<StatusType>) {
-        val isExistStatusPicnic = statusTypes.contains(StatusType.PICNIC)
-        if (isExistStatusPicnic) {
+    private fun checkIsStatusPicnicOrAwait(statusTypes: List<StatusType>) {
+        val isExistStatusPicnicOrAwait = statusTypes.contains(StatusType.PICNIC) || statusTypes.contains(StatusType.AWAIT)
+        if (isExistStatusPicnicOrAwait) {
             throw CannotMovementException
         }
     }


### PR DESCRIPTION
- 교실 이동 신청 시 기존의 외출 상태 일 때에만 예외 처리를 했던 것을 외출 상태이거나 외출 대기 상태일때 예외 처리를 하도록 변경하였습니다.